### PR TITLE
Fix java.lang.IllegalStateException

### DIFF
--- a/src/main/java/com/pbaranchikov/stash/checks/EolCheckHook.java
+++ b/src/main/java/com/pbaranchikov/stash/checks/EolCheckHook.java
@@ -233,6 +233,7 @@ public class EolCheckHook implements PreReceiveRepositoryHook, RepositoryMergeRe
             for (Pattern pattern : excludeFiles) {
                 if (pattern.matcher(filename).matches()) {
                     iter.remove();
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Fix java.lang.IllegalStateException thrown by HashMap$HashIterator on calling remove() without next.

2015-05-20 07:58:29,461 WARN  [threadpool:thread-13371] artem.grebenkin @1CKWJ07x478x269247x0 153.95.94.44 "POST /scm/bcom/holding.git/git-receive-pack HTTP/1.1" c.a.s.i.h.r.PreReceiveRepositoryHookAdapter Receive Hook com.pbaranchikov.stash.checks.EolCheckHook failed.
java.lang.IllegalStateException: null
        at java.util.HashMap$HashIterator.remove(HashMap.java:938) ~[na:1.7.0_71]
        at com.pbaranchikov.stash.checks.EolCheckHook.filterFiles(EolCheckHook.java:235) ~[na:na]
        at com.pbaranchikov.stash.checks.EolCheckHook.getChangedPaths(EolCheckHook.java:157) ~[na:na]
        at com.pbaranchikov.stash.checks.EolCheckHook.processChange(EolCheckHook.java:176) ~[na:na]
        at com.pbaranchikov.stash.checks.EolCheckHook.onReceive(EolCheckHook.java:77) ~[na:na]
        at com.atlassian.stash.internal.hook.repository.PreReceiveRepositoryHookAdapter$1.visit(PreReceiveRepositoryHookAdapter.java:38) [PreReceiveRepositoryHookAdapter$1.class:na]
        at com.atlassian.stash.internal.hook.repository.PreReceiveRepositoryHookAdapter$1.visit(PreReceiveRepositoryHookAdapter.java:33) [PreReceiveRepositoryHookAdapter$1.class:na]
        at com.atlassian.stash.internal.hook.repository.DefaultRepositoryHookService$RepositoryHookPagedTransactionCallback.doInTransaction(DefaultRepositoryHookService.java:616) [DefaultRepositoryHookService$RepositoryHookPagedTransactionCallback.class:na]
        at com.atlassian.stash.internal.hook.repository.DefaultRepositoryHookService$RepositoryHookPagedTransactionCallback.doInTransaction(DefaultRepositoryHookService.java:592) [DefaultRepositoryHookService$RepositoryHookPagedTransactionCallback.class:na]
        at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:133) [TransactionTemplate.class:4.1.1.RELEASE]
        at com.atlassian.stash.internal.hook.repository.DefaultRepositoryHookService.visitEnabledHooks(DefaultRepositoryHookService.java:304) [DefaultRepositoryHookService.class:na]
        at com.atlassian.stash.internal.plugin.OsgiSafeProxyProvider$1.invoke(OsgiSafeProxyProvider.java:93) [OsgiSafeProxyProvider$1.class:na]
        at com.atlassian.stash.internal.hook.repository.PreReceiveRepositoryHookAdapter.onReceive(PreReceiveRepositoryHookAdapter.java:33) [PreReceiveRepositoryHookAdapter.class:na]
        at com.atlassian.stash.internal.hook.DefaultBuiltInHookHandlerFactory$1.handle(DefaultBuiltInHookHandlerFactory.java:43) [DefaultBuiltInHookHandlerFactory$1.class:na]
        at com.atlassian.stash.internal.hook.DefaultHookService.doHandleRequest(DefaultHookService.java:353) [DefaultHookService.class:na]
        at com.atlassian.stash.internal.hook.DefaultHookService.handleRequest(DefaultHookService.java:339) [DefaultHookService.class:na]
        at com.atlassian.stash.internal.hook.DefaultHookService.handleRawRequest(DefaultHookService.java:250) [DefaultHookService.class:na]
        at com.atlassian.stash.internal.hook.DefaultHookService$2$1.run(DefaultHookService.java:210) [DefaultHookService$2$1.class:na]
        at com.atlassian.stash.internal.concurrent.StateTransferringExecutor$StateTransferringRunnable.run(StateTransferringExecutor.java:69) [StateTransferringExecutor$StateTransferringRunnable.class:na]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [na:1.7.0_71]
        at java.util.concurrent.FutureTask.run(FutureTask.java:262) [na:1.7.0_71]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:178) [na:1.7.0_71]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:292) [na:1.7.0_71]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [na:1.7.0_71]
        at java.lang.Thread.run(Thread.java:745) [na:1.7.0_71]
        ... 35 frames trimmed
